### PR TITLE
v0.2.0: longline behaviour, unified :Faster command, modernized inter…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Faster.nvim is a Neovim plugin inspired by
 bigfile.nvim concept and code for handling of big files has been used as a
 starting point for faster.nvim.
 
-Some Neovim plugins and features can make Neovim slow when editing big files and
-executing macros. Faster.nvim will selectively disable some features when big
-file is opened or macro is executed.
+Some Neovim plugins and features can make Neovim slow when editing big files,
+files with very long lines (minified JS/JSON/CSS), or while executing macros.
+Faster.nvim will selectively disable some features when a big file is opened,
+a long-line file is opened, or a macro is executed.
 
 Faster.nvim also gives ability to define custom behaviours and features so user
 can disable other plugins or Neovim options based on custom behaviour or the
@@ -114,6 +115,46 @@ opts = {
       ]]
       -- By default `extra_patterns` is an empty table: {}.
       extra_patterns = {},
+      -- When true, fires a one-shot `vim.notify` (INFO level, title
+      -- "faster.nvim") each time bigfile mode activates for a buffer,
+      -- e.g. "faster.nvim active for big_log.txt (5.3 MiB)". Works with
+      -- any notify plugin (nvim-notify, noice, mini.notify, snacks.notifier)
+      -- and falls back to the built-in command-line message if no plugin
+      -- replaces vim.notify. On launch-with-file-arg (e.g. `nvim big.log`),
+      -- the message may still land in the cmdline if your notify plugin
+      -- lazy-loads after BufReadPost. Set to false to silence.
+      notify = true,
+    },
+    -- Long-line behaviour catches files that aren't large in total bytes but
+    -- have very long lines (minified JS/JSON/CSS, single-line log files).
+    -- These choke treesitter and syntax highlighting harder than typical big
+    -- files, but bigfile detection misses them because their byte count is
+    -- low. Detection uses filesize / line_count as a cheap heuristic.
+    longline = {
+      on = true,
+      -- Same shape as bigfile.features_disabled. "all" is also accepted.
+      features_disabled = {
+        'illuminate', 'matchparen', 'lsp',
+        'treesitter', 'indent_blankline',
+        'vimopts', 'syntax', 'filetype',
+      },
+      -- File must be at least this size (MiB) to be considered. Default
+      -- 10 KiB skips tiny files even if their line count is artificially low.
+      filesize = 0.01,
+      -- Trigger when filesize_bytes / line_count > avg_bytes_per_line.
+      avg_bytes_per_line = 250,
+      pattern = "*",
+      -- Same extra_patterns shape as bigfile; both filesize and
+      -- avg_bytes_per_line are overridable per pattern.
+      --[[
+      extra_patterns = {
+        { pattern = "*.js",  avg_bytes_per_line = 200 },
+        { pattern = "*.css", filesize = 0.05 },
+      },
+      ]]
+      extra_patterns = {},
+      -- Same vim.notify behaviour as bigfile (see notify above).
+      notify = true,
     },
     -- Fast macro configuration controls disabling and enabling features when
     -- macro is executed
@@ -246,52 +287,97 @@ test_feature = {
   enable = function() print('this should enable a feature') end,
   -- disable key takes a function that contains code that will disable a feature
   disable = function() print('this should disable a feature') end,
-  -- commands key takes a function that should be used to define commands that
-  -- will enable/disable a feature in runtime
-  commands = function()
-    vim.api.nvim_create_user_command(
-      'FasterEnableTestfeature', print('Test feature enabled'), {})
-    vim.api.nvim_create_user_command(
-      'FasterDisableTestfeature', print('Test feature disabled'), {})
-  end,
 },
+```
+
+The feature is automatically reachable through the unified `:Faster` command
+once registered (see Commands below):
+
+```
+:Faster enable test_feature
+:Faster disable test_feature
 ```
 
 # Commands
 
-Although faster.nvim will disable and enable features based on the rules defined
-in a behaviour it also offers convenience commands that can be used during
-Neovim execution without restarting it.
+faster.nvim exposes a single user command, `:Faster`, with subcommands for
+runtime control. Tab-completion suggests valid actions and targets at every
+position.
 
-Note that disabling and enabling features will work only if the feature has `on`
-set to `true` in the configuration.
+```
+:Faster <action> [target]
+```
 
-| Command                      | Description                                                                                                      |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| FasterDisableAllFeatures     | Disables all defined features that are on                                                                        |
-| FasterDisableBigfile         | Disables bigfile behaviour                                                                                       |
-| FasterDisableFastmacro       | Disables fastmacro behaviour                                                                                     |
-| FasterDisableFiletype        | Disables filetype for the current buffer                                                                         |
-| FasterDisableIlluminate      | Disables illuminate plugin for the current buffer                                                                |
-| FasterDisableIndentblankline | Disables indent blank line plugin globally                                                                       |
-| FasterDisableLsp             | Disables LSP client for currently opened buffers. Will not disable LSP for any new buffers opened.               |
-| FasterDisableLualine         | Disables lualine plugin globally                                                                                 |
-| FasterDisableMiniClue        | Disables mini.clue plugin triggers globally                                                                      |
-| FasterDisableMatchparen      | Disables parentheses matching globally, even for newly opened buffers                                            |
-| FasterDisableSyntax          | Disabled default syntax highlighting for current buffer                                                          |
-| FasterDisableTreesitter      | Disables treesitter for the current buffer                                                                       |
-| FasterDisableVimopts         | Disable neovim options connected to slowness of Neovim when big files are opened but only for the current buffer |
-| FasterEnableAllFeatures      | Enables all defined features that are on                                                                         |
-| FasterEnableBigfile          | Enables bigfile behaviour                                                                                        |
-| FasterEnableFastmacro        | Enables fastmacro behaviour                                                                                      |
-| FasterEnableFiletype         | Enables filetype for the current buffer                                                                          |
-| FasterEnableIlluminate       | Enables illuminate for the current buffer                                                                        |
-| FasterEnableIndentblankline  | Enables indent blank line plugin globally                                                                        |
-| FasterEnableLsp              | Enables LSP client for currently opened buffers                                                                  |
-| FasterEnableLualine          | Enables lualine plugin globally                                                                                  |
-| FasterEnableMiniClue         | Enables mini.clue plugin triggers globally                                                                       |
-| FasterEnableMatchparen       | Enables parentheses matching globally                                                                            |
-| FasterEnableSyntax           | Enables default syntax highlighting for current buffer                                                           |
-| FasterEnableTreesitter       | Enables treesitter for the current buffer                                                                        |
-| FasterEnableVimopts          | Enables neovim options connected to slowness of Neovim whn bif files are opened but only for the current buffer  |
-| FasterPrintConfig            | Prints faster.nvim configuration. Takes into account default configuration and user defined one and merges them. |
+Note that enabling/disabling a feature only takes effect if the feature has
+`on = true` in the configuration.
+
+## Actions
+
+| Action  | Argument                  | What it does                                                                |
+| ------- | ------------------------- | --------------------------------------------------------------------------- |
+| enable  | `<behaviour>` / `<feature>` / `features` / `behaviours` / `all` | Re-enables a behaviour or feature. Group targets (`features`, `behaviours`, `all`) act on every member at once. Group `enable` only re-arms behaviours, it does NOT re-process the current buffer (so just-enabled features stay enabled). |
+| disable | `<behaviour>` / `<feature>` / `features` / `behaviours` / `all` | Disables a behaviour or feature. Group targets disable every member at once. |
+| config  | —                         | Prints the merged faster.nvim configuration (defaults + user overrides)      |
+| status  | —                         | Prints behaviour/feature `on` (config) plus runtime `active` state for the current buffer |
+| help    | —                         | Prints usage and the list of valid targets                                   |
+
+## Targets
+
+**Behaviours:** `bigfile`, `longline`, `fastmacro`
+
+**Features:** `illuminate`, `matchparen`, `lsp`, `treesitter`, `indent_blankline`, `vimopts`, `syntax`, `filetype`, `lualine`, `mini_clue`
+
+**Group targets:**
+- `features` — every feature with `on=true`
+- `behaviours` — every behaviour (init/stop all at once)
+- `all` — every behaviour AND every feature
+
+## Examples
+
+```
+:Faster enable bigfile          " re-arm the bigfile behaviour after disabling it
+:Faster disable bigfile         " stop bigfile from triggering on file open
+:Faster disable features        " disable every feature whose on=true
+:Faster disable behaviours      " stop bigfile + longline + fastmacro
+:Faster disable all             " disable every behaviour AND every feature
+:Faster enable all              " re-arm everything
+:Faster enable treesitter       " re-enable treesitter for the current buffer
+:Faster disable mini_clue       " disable mini.clue triggers globally
+:Faster status                  " quick view of config + runtime state
+:Faster config                  " print the merged config
+```
+
+## `:Faster status`
+
+Two columns:
+
+- `on` — the static config flag (whether faster.nvim is configured to control this).
+- `active` — the runtime state probed against the current buffer:
+  - For **behaviours** (`bigfile`, `longline`): `true` once the behaviour has triggered for this buffer (criteria matched and features were disabled). `fastmacro` reports whether the `@` keymap interception is installed (global, not per-buffer).
+  - For **features**: whether the feature is currently enabled in this buffer, queried via plugin-specific probes (e.g. `vim.treesitter.highlighter.active[bufnr]`, `&syntax`, LSP client count, IBL config).
+  - `?` means the runtime state can't be reliably probed. Currently only `illuminate` — vim-illuminate's public `is_paused()` only reports a global flag, not per-buffer state, so we can't tell whether the active buffer is paused. (`lualine` and `mini_clue` track state through internal flags set by `:Faster enable/disable`, so they report a real true/false.)
+
+Example on a 4 MiB markdown file (bigfile-triggered, longline criteria not met):
+
+```
+faster.nvim status (buffer 1: 3Mfile.md)
+
+  behaviours:               on        active
+    bigfile                   true      true
+    fastmacro                 true      true
+    longline                  true      false
+
+  features:                 on        active
+    filetype                  true      false
+    illuminate                true      ?
+    indent_blankline          true      false
+    lsp                       true      false
+    lualine                   true      true
+    matchparen                true      false
+    mini_clue                 true      true
+    syntax                    true      false
+    treesitter                true      false
+    vimopts                   true      false
+```
+
+`lualine` and `mini_clue` `active=true` here is correct — bigfile's default `features_disabled` doesn't include them (they're in `fastmacro`'s list).

--- a/lua/faster/behaviours.lua
+++ b/lua/faster/behaviours.lua
@@ -10,8 +10,45 @@ M.bigfile = {
   filesize = 2,
   pattern = "*",
   extra_patterns = {},
+  -- Show a one-shot vim.notify when bigfile mode activates for a buffer.
+  notify = true,
   init = require('faster.bigfile').init,
   stop = require('faster.bigfile').stop,
+  -- Active = bigfile criteria matched for this buffer (features were disabled).
+  -- The disable_features path sets vim.b[bufnr].faster_bigfile_triggered.
+  is_active = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local ok, val = pcall(vim.api.nvim_buf_get_var, bufnr, 'faster_bigfile_triggered')
+    return ok and val == true
+  end,
+}
+
+-- Triggers on files that aren't large in total bytes but have very long lines
+-- (minified JS, JSON, log files). avg = filesize / line_count is a cheap
+-- heuristic: it requires only fs_stat + nvim_buf_line_count, no buffer scan.
+M.longline = {
+  on = true,
+  features_disabled = {
+    'illuminate', 'matchparen', 'lsp',
+    'treesitter', 'indent_blankline',
+    'vimopts', 'syntax', 'filetype',
+  },
+  -- File must be at least this size (MiB) to be considered. Default 10 KiB
+  -- skips tiny files even if their line count is artificially low.
+  filesize = 0.01,
+  -- Trigger when filesize_bytes / line_count > avg_bytes_per_line.
+  avg_bytes_per_line = 250,
+  pattern = "*",
+  extra_patterns = {},
+  notify = true,
+  init = require('faster.longline').init,
+  stop = require('faster.longline').stop,
+  -- Active = longline criteria matched for this buffer (features were disabled).
+  is_active = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local ok, val = pcall(vim.api.nvim_buf_get_var, bufnr, 'faster_longline_triggered')
+    return ok and val == true
+  end,
 }
 
 M.fastmacro = {
@@ -19,6 +56,11 @@ M.fastmacro = {
   features_disabled = { "lualine", "mini_clue"},
   init = require('faster.macro').init,
   stop = require('faster.macro').stop,
+  -- Active = the @ keymap is bound to our wrapper. init() sets it, stop() unsets.
+  is_active = function()
+    local m = vim.fn.maparg("@", "n", false, true)
+    return type(m) == "table" and (m.callback ~= nil or m.rhs ~= nil and m.rhs ~= "")
+  end,
 }
 
 return M

--- a/lua/faster/bigfile.lua
+++ b/lua/faster/bigfile.lua
@@ -11,16 +11,44 @@ local function get_buf_size(bufnr)
   return math.floor(0.5 + (stats.size / (1024 * 1024)) * 10) / 10
 end
 
-local function disable_features(bufnr, for_size, defer)
-  local filesize = get_buf_size(bufnr) or 0
-  local bigfile_detected = filesize >= for_size
-  if bigfile_detected then
+local function emit_notify(bufnr, filesize)
+  local fname = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
+  local msg = string.format("faster.nvim active for %s (%s MiB)", fname, filesize)
+  local function emit()
+    vim.notify(msg, vim.log.levels.INFO, { title = "faster.nvim" })
+  end
+  if vim.v.vim_did_enter == 1 then
+    emit()
+  else
+    -- Race-defensive: prefer User VeryLazy (lazy.nvim fires it after VeryLazy
+    -- plugins like nvim-notify replace vim.notify), fall back to UIEnter+timer.
+    local fired = false
+    local function fire()
+      if fired then return end
+      fired = true
+      emit()
+    end
+    pcall(vim.api.nvim_create_autocmd, "User", {
+      pattern = "VeryLazy",
+      once = true,
+      callback = fire,
+    })
+    vim.api.nvim_create_autocmd("UIEnter", {
+      once = true,
+      callback = function() vim.defer_fn(fire, 500) end,
+    })
+  end
+end
+
+-- Run disable for features at one defer level inside the bufnr's context.
+local function run_disable_pass(bufnr, defer)
+  vim.api.nvim_buf_call(bufnr, function()
     utils.run_on_features(
       FasterConfig.behaviours.bigfile.features_disabled,
       function(f) f.disable() end,
       function(f) return f.defer == defer end
     )
-  end
+  end)
 end
 
 local function enable_features(defer)
@@ -31,62 +59,92 @@ local function enable_features(defer)
   )
 end
 
+-- Three-pass disable for one buffer. defer=true side-effects (setting
+-- filetype="") synchronously fire FileType autocmds; user code on FileType
+-- (e.g. vim.treesitter.start) can re-enable defer=false features. We re-run
+-- defer=false on the next tick to override that.
+local function disable_for_buffer(bufnr)
+  pcall(vim.api.nvim_buf_set_var, bufnr, 'faster_bigfile_triggered', true)
+  run_disable_pass(bufnr, false)
+  run_disable_pass(bufnr, true)
+  vim.schedule(function()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      run_disable_pass(bufnr, false)
+    end
+  end)
+end
+
 local M = {}
 
-function M.init()
+local function on_buffer(bufnr, for_size)
+  vim.schedule(function()
+    if not vim.api.nvim_buf_is_valid(bufnr) then return end
+    local filesize = get_buf_size(bufnr) or 0
+    if filesize < for_size then return end
+    if FasterConfig.behaviours.bigfile.notify then
+      emit_notify(bufnr, filesize)
+    end
+    disable_for_buffer(bufnr)
+  end)
+end
+
+-- Find the threshold that applies to a given buffer (default + extra_patterns).
+local function threshold_for_buffer(bufnr)
+  local cfg = FasterConfig.behaviours.bigfile
+  local fname = vim.api.nvim_buf_get_name(bufnr)
+  for _, override in ipairs(cfg.extra_patterns or {}) do
+    if override.pattern and vim.fn.match(fname, vim.fn.glob2regpat(override.pattern)) >= 0 then
+      return override.filesize or cfg.filesize
+    end
+  end
+  return cfg.filesize
+end
+
+function M.init(opts)
+  opts = opts or {}
   local augroup = vim.api.nvim_create_augroup('faster_bigfile', {})
+  local cfg = FasterConfig.behaviours.bigfile
 
-  vim.api.nvim_create_autocmd("BufReadPre", {
-    pattern = FasterConfig.behaviours.bigfile.pattern,
-    group = augroup,
-    callback = function(args)
-      disable_features(args.buf, FasterConfig.behaviours.bigfile.filesize,false)
-    end,
-    desc = string.format(
-      "[faster.nvim] Performance rule for handling files over %sMiB",
-      FasterConfig.behaviours.bigfile.filesize
-    ),
-  })
-
+  -- BufReadPost: buffer is fully loaded; defer with vim.schedule so we run
+  -- AFTER the BufReadPost -> FileType chain. Otherwise user FileType autocmds
+  -- (e.g. vim.treesitter.start) re-enable features after our disable.
   vim.api.nvim_create_autocmd("BufReadPost", {
-    pattern = FasterConfig.behaviours.bigfile.pattern,
+    pattern = cfg.pattern,
     group = augroup,
     callback = function(args)
-      disable_features(args.buf, FasterConfig.behaviours.bigfile.filesize, true)
+      on_buffer(args.buf, cfg.filesize)
     end,
     desc = string.format(
       "[faster.nvim] Performance rule for handling files over %sMiB",
-      FasterConfig.behaviours.bigfile.filesize
+      cfg.filesize
     ),
   })
 
-  for _, override in ipairs(FasterConfig.behaviours.bigfile.extra_patterns or {}) do
+  for _, override in ipairs(cfg.extra_patterns or {}) do
     if override.pattern ~= nil then
-      vim.api.nvim_create_autocmd("BufReadPre", {
-        pattern = override.pattern,
-        group = augroup,
-        callback = function(args)
-          disable_features(args.buf, override.filesize or FasterConfig.behaviours.bigfile.filesize,false)
-        end,
-        desc = string.format(
-          "[faster.nvim] Performance rule for handling `%s` files over %sMiB",
-          override.pattern,
-          override.filesize or FasterConfig.behaviours.bigfile.filesize
-        ),
-      })
-
+      local fs = override.filesize or cfg.filesize
       vim.api.nvim_create_autocmd("BufReadPost", {
         pattern = override.pattern,
         group = augroup,
         callback = function(args)
-          disable_features(args.buf, override.filesize or FasterConfig.behaviours.bigfile.filesize, true)
+          on_buffer(args.buf, fs)
         end,
         desc = string.format(
           "[faster.nvim] Performance rule for handling `%s` files over %sMiB",
-          override.pattern,
-          override.filesize or  FasterConfig.behaviours.bigfile.filesize
+          override.pattern, fs
         ),
       })
+    end
+  end
+
+  -- Process the currently open buffer too: useful when init() is called via
+  -- :Faster enable bigfile while sitting on an already-open big file. Skip
+  -- when init() is part of a group enable (:Faster enable all|behaviours) —
+  -- the user explicitly asked for everything to be on, so don't re-disable.
+  if not opts.skip_current then
+    local cur = vim.api.nvim_get_current_buf()
+    if vim.api.nvim_buf_get_name(cur) ~= "" then
+      on_buffer(cur, threshold_for_buffer(cur))
     end
   end
 end
@@ -95,6 +153,12 @@ function M.stop()
   vim.api.nvim_del_augroup_by_name('faster_bigfile')
   enable_features(true)
   enable_features(false)
+  -- Clear stale per-buffer "triggered" markers so :Faster status reports
+  -- runtime state honestly. Using nvim_list_bufs covers any buffer we may
+  -- have flagged earlier; pcall guards against unloaded buffers.
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    pcall(vim.api.nvim_buf_del_var, bufnr, 'faster_bigfile_triggered')
+  end
 end
 
 return M

--- a/lua/faster/commands.lua
+++ b/lua/faster/commands.lua
@@ -1,19 +1,258 @@
 local utils = require('faster.utils')
 
--- Features
+-- Build the dispatch tables once, after FasterConfig is populated by setup().
 
-vim.api.nvim_create_user_command('FasterEnableAllFeatures', utils.enable_all_features, {})
-vim.api.nvim_create_user_command('FasterDisableAllFeatures', utils.disable_all_features, {})
+---@type table<string, fun()>
+local enable  = {}
+---@type table<string, fun()>
+local disable = {}
 
+local function notify_action(action, target)
+  vim.notify(
+    string.format("faster.nvim: %s %s", action, target),
+    vim.log.levels.INFO,
+    { title = "faster.nvim" }
+  )
+end
 
--- Behaviours
+-- Behaviours (bigfile, fastmacro, ...): toggle runtime + config flag.
+for name, b in pairs(FasterConfig.behaviours) do
+  enable[name] = function()
+    b.on = true
+    b.init()
+    notify_action("enabled behaviour", name)
+  end
+  disable[name] = function()
+    b.stop()
+    b.on = false
+    notify_action("disabled behaviour", name)
+  end
+end
 
-vim.api.nvim_create_user_command('FasterEnableBigfile', utils.enable_big_file, {})
-vim.api.nvim_create_user_command('FasterDisableBigfile', utils.disable_big_file, {})
+-- Group targets: all features, all behaviours, or everything.
+local function enable_all_features_with_flag()
+  -- Enable defer=true features (filetype, syntax, vimopts) first so that
+  -- features that depend on them (e.g. lsp reads &filetype) see the restored
+  -- values when they enable. pairs() ordering is undefined, so we explicitly
+  -- run two passes.
+  for _, f in pairs(FasterConfig.features) do
+    if f.defer == true then
+      f.on = true
+      f.enable()
+    end
+  end
+  for _, f in pairs(FasterConfig.features) do
+    if f.defer ~= true then
+      f.on = true
+      f.enable()
+    end
+  end
+end
+local function disable_all_features_with_flag()
+  for _, f in pairs(FasterConfig.features) do
+    f.disable()
+    f.on = false
+  end
+end
+local function enable_all_behaviours()
+  -- skip_current = true: re-arm autocmds but don't process the currently
+  -- open buffer. Group enable means "everything on now"; processing the
+  -- current buffer here would queue a feature disable that immediately
+  -- undoes the feature enable that happens right after.
+  for _, b in pairs(FasterConfig.behaviours) do
+    b.on = true
+    b.init({ skip_current = true })
+  end
+end
+local function disable_all_behaviours()
+  for _, b in pairs(FasterConfig.behaviours) do
+    b.stop()
+    b.on = false
+  end
+end
 
-vim.api.nvim_create_user_command('FasterEnableFastmacro', utils.enable_fast_macro, {})
-vim.api.nvim_create_user_command('FasterDisableFastmacro', utils.disable_fast_macro, {})
+enable.features = function()
+  enable_all_features_with_flag()
+  notify_action("enabled", "all features")
+end
+disable.features = function()
+  disable_all_features_with_flag()
+  notify_action("disabled", "all features")
+end
 
--- Utilities
+enable.behaviours = function()
+  enable_all_behaviours()
+  notify_action("enabled", "all behaviours")
+end
+disable.behaviours = function()
+  disable_all_behaviours()
+  notify_action("disabled", "all behaviours")
+end
 
-vim.api.nvim_create_user_command('FasterPrintConfig', utils.print_config, {})
+enable.all = function()
+  enable_all_behaviours()
+  enable_all_features_with_flag()
+  notify_action("enabled", "all behaviours and features")
+end
+disable.all = function()
+  disable_all_behaviours()
+  disable_all_features_with_flag()
+  notify_action("disabled", "all behaviours and features")
+end
+
+-- Individual features (illuminate, matchparen, lsp, treesitter, ...).
+-- Toggling f.on lets behaviours skip features the user opted out of.
+for name, f in pairs(FasterConfig.features) do
+  enable[name] = function()
+    f.on = true
+    f.enable()
+    notify_action("enabled feature", name)
+  end
+  disable[name] = function()
+    f.disable()
+    f.on = false
+    notify_action("disabled feature", name)
+  end
+end
+
+local actionless = {
+  config = function() utils.print_config() end,
+  status = function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local lines = {
+      string.format("faster.nvim status (buffer %d: %s)",
+        bufnr, vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")),
+      "",
+      "  behaviours:               on        active",
+    }
+    -- Sort behaviour names for stable output.
+    local bnames = vim.tbl_keys(FasterConfig.behaviours)
+    table.sort(bnames)
+    for _, name in ipairs(bnames) do
+      local b = FasterConfig.behaviours[name]
+      local active_str
+      if type(b.is_active) == "function" then
+        local ok, result = pcall(b.is_active, bufnr)
+        if not ok then
+          active_str = "error"
+        elseif result == nil then
+          active_str = "?"
+        else
+          active_str = tostring(result)
+        end
+      else
+        active_str = "?"
+      end
+      table.insert(lines, string.format("    %-22s    %-7s   %s",
+        name, tostring(b.on), active_str))
+    end
+    table.insert(lines, "")
+    table.insert(lines, "  features:                 on        active")
+    -- Sort feature names for stable output.
+    local fnames = vim.tbl_keys(FasterConfig.features)
+    table.sort(fnames)
+    for _, name in ipairs(fnames) do
+      local f = FasterConfig.features[name]
+      local active_str
+      if type(f.is_active) == "function" then
+        local ok, result = pcall(f.is_active, bufnr)
+        if not ok then
+          active_str = "error"
+        elseif result == nil then
+          active_str = "?"
+        else
+          active_str = tostring(result)
+        end
+      else
+        active_str = "?"
+      end
+      table.insert(lines, string.format("    %-22s    %-7s   %s",
+        name, tostring(f.on), active_str))
+    end
+    print(table.concat(lines, "\n"))
+  end,
+  help = function()
+    local targets = vim.tbl_keys(enable)
+    table.sort(targets)
+    print(table.concat({
+      "Usage: :Faster <command> [target]",
+      "",
+      "  enable  <target>",
+      "  disable <target>",
+      "  config",
+      "  status",
+      "  help",
+      "",
+      "Targets: " .. table.concat(targets, ", "),
+    }, "\n"))
+  end,
+}
+
+local actions = { enable = enable, disable = disable }
+
+local function dispatch(opts)
+  local args = opts.fargs
+  if #args == 0 then
+    actionless.help()
+    return
+  end
+
+  local action = args[1]
+
+  if actionless[action] then
+    actionless[action]()
+    return
+  end
+
+  local targets = actions[action]
+  if not targets then
+    utils.print_error(string.format(
+      "[faster.nvim] unknown command: %q. Try `:Faster help`.", action
+    ))
+    return
+  end
+
+  local target = args[2]
+  if not target then
+    utils.print_error(string.format(
+      "[faster.nvim] :Faster %s needs a target. Try `:Faster help`.", action
+    ))
+    return
+  end
+
+  local handler = targets[target]
+  if not handler then
+    utils.print_error(string.format(
+      "[faster.nvim] unknown target %q for `:Faster %s`. Try `:Faster help`.", target, action
+    ))
+    return
+  end
+
+  handler()
+end
+
+-- Tab-completion: top-level commands at position 1, targets at position 2.
+local top_level = { "enable", "disable", "config", "status", "help" }
+
+local function complete(arglead, cmdline, _)
+  local args = vim.split(cmdline, "%s+", { trimempty = false })
+  local function filter(list)
+    return vim.tbl_filter(function(x)
+      return x:find("^" .. vim.pesc(arglead)) ~= nil
+    end, list)
+  end
+  if #args <= 2 then
+    return filter(top_level)
+  elseif #args == 3 and (args[2] == "enable" or args[2] == "disable") then
+    local list = vim.tbl_keys(actions[args[2]])
+    table.sort(list)
+    return filter(list)
+  end
+  return {}
+end
+
+vim.api.nvim_create_user_command("Faster", dispatch, {
+  nargs = "*",
+  complete = complete,
+  desc = "faster.nvim — :Faster help for usage",
+})

--- a/lua/faster/features.lua
+++ b/lua/faster/features.lua
@@ -6,24 +6,42 @@ local M = {}
 M.illuminate = {
   on = true,
   defer = false,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableIlluminate', M.illuminate.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableIlluminate', M.illuminate.disable, {})
-  end,
-
+  -- Use the Lua API directly so that requiring forces vim-illuminate to load
+  -- (it's commonly lazy-loaded on CursorHold, in which case the
+  -- :IlluminatePauseBuf user command doesn't exist yet at BufReadPost time).
   enable = function()
-    if vim.fn.exists(':IlluminateResumeBuf') ~= 2 then
-      return
-    end
-    vim.cmd('IlluminateResumeBuf')
+    pcall(function()
+      require('illuminate').resume_buf()
+      -- resume_buf only clears the per-buffer pause flag; illuminate refreshes
+      -- highlights on CursorMoved. Force one so the user sees results
+      -- immediately after :Faster enable illuminate without having to move
+      -- the cursor.
+      pcall(function()
+        require('illuminate.engine').refresh_references(
+          vim.api.nvim_get_current_buf(),
+          vim.api.nvim_get_current_win()
+        )
+      end)
+    end)
   end,
 
   disable = function()
-    if vim.fn.exists(':IlluminatePauseBuf') ~= 2 then
-      return
+    pcall(function() require('illuminate').pause_buf() end)
+  end,
+
+  -- vim-illuminate's public `is_paused()` only returns the global pause flag,
+  -- not per-buffer state. `pause_buf()` correctly sets a per-buffer flag
+  -- internally, but there's no public probe for it. We return nil ("?") for
+  -- per-buffer queries; users can verify via "do I see other instances of
+  -- the word under cursor highlighted?".
+  is_active = function(_)
+    local ok, illuminate = pcall(require, 'illuminate')
+    if not ok then return nil end
+    -- If the global pause flag is set, illuminate is definitely off.
+    if type(illuminate.is_paused) == 'function' and illuminate.is_paused() then
+      return false
     end
-    vim.cmd('IlluminatePauseBuf')
+    return nil
   end,
 }
 
@@ -32,12 +50,6 @@ M.illuminate = {
 M.matchparen = {
   on = true,
   defer = false,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableMatchparen', M.matchparen.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableMatchparen', M.matchparen.disable, {})
-  end,
-
   enable = function()
     if vim.fn.exists(':DoMatchParen') ~= 2 then
       return
@@ -50,7 +62,12 @@ M.matchparen = {
       return
     end
     vim.cmd('NoMatchParen')
-  end
+  end,
+
+  is_active = function(_)
+    -- :NoMatchParen sets g:loaded_matchparen = 0 (or undefines it).
+    return vim.g.loaded_matchparen == 1
+  end,
 }
 
 -- LSP
@@ -58,13 +75,20 @@ M.matchparen = {
 M.lsp = {
   on = true,
   defer = false,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableLsp', M.lsp.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableLsp', M.lsp.disable, {})
-  end,
-
   enable = function()
+    -- Filetype check first — warn even if :LspStart isn't available, since
+    -- "filetype is empty" is the actionable signal for the user. :LspStart
+    -- resolves the server from &filetype; with an empty filetype no server
+    -- matches and the start is a silent no-op.
+    if vim.bo.filetype == "" then
+      vim.notify(
+        "[faster.nvim] LSP enable skipped — &filetype is empty. " ..
+        "Run `:Faster enable filetype` first.",
+        vim.log.levels.WARN,
+        { title = "faster.nvim" }
+      )
+      return
+    end
     if vim.fn.exists(':LspStart') ~= 2 then
       return
     end
@@ -76,69 +100,40 @@ M.lsp = {
       return
     end
     vim.cmd('LspStop')
-  end
+  end,
+
+  is_active = function(bufnr)
+    bufnr = bufnr or 0
+    return #vim.lsp.get_clients({ bufnr = bufnr }) > 0
+  end,
 }
 
 
 -- Treesitter
-
-local treesitter_backup = {}
-local treesitter_disabled = false
+--
+-- Uses Neovim's built-in vim.treesitter API (stable since 0.9), which works
+-- for both nvim-treesitter v0.x (master) and v1 (main / archived). The old
+-- v0.x API (require 'nvim-treesitter.configs', :TSBufDisable, available_modules)
+-- was removed in v1 and would silently no-op there.
 
 M.treesitter = {
   on = true,
   defer = false,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableTreesitter', M.treesitter.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableTreesitter', M.treesitter.disable, {})
-  end,
-
   enable = function()
-    local status_ok, _ = pcall(require, 'nvim-treesitter.configs')
-    if not status_ok then
-      return
-    end
-
-    if vim.fn.exists(':TSBufEnable') ~= 2 then
-      return
-    end
-
-    if treesitter_disabled == true then
-      -- Return treesitter module state from backup
-      for _, mod_state in ipairs(treesitter_backup) do
-        if mod_state.enable then
-          vim.cmd('TSBufEnable ' .. mod_state.mod_name)
-        end
-      end
-      treesitter_disabled = false
-    end
+    pcall(vim.treesitter.start, 0)
   end,
 
   disable = function()
-    local status_ok, ts_config = pcall(require, 'nvim-treesitter.configs')
-    if not status_ok then
-      return
-    end
+    pcall(vim.treesitter.stop, 0)
+  end,
 
-    if vim.fn.exists(':TSBufDisable') ~= 2 then
-      return
-    end
-
-    -- Backup current treesitter module "enable" state
-    if treesitter_disabled == false then
-      for _, mod_name in ipairs(ts_config.available_modules()) do
-        local module_config = ts_config.get_module(mod_name) or {}
-        table.insert(treesitter_backup, { mod_name = mod_name, enable = module_config.enable })
-      end
-      treesitter_disabled = true
-    end
-
-    for _, mod_name in ipairs(ts_config.available_modules()) do
-      vim.cmd('TSBufDisable ' .. mod_name)
-    end
-  end
-
+  is_active = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    -- vim.treesitter.highlighter.active is keyed by bufnr.
+    local ok, hl = pcall(require, 'vim.treesitter.highlighter')
+    if not ok or not hl then return nil end
+    return hl.active and hl.active[bufnr] ~= nil
+  end,
 }
 
 -- Indent Blankline
@@ -147,12 +142,6 @@ M.treesitter = {
 M.indent_blankline = {
   on = true,
   defer = false,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableIndentblankline', M.indent_blankline.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableIndentblankline', M.indent_blankline.disable, {})
-  end,
-
   enable = function()
     if vim.fn.exists(':IBLEnable') ~= 2 then
       return
@@ -165,7 +154,16 @@ M.indent_blankline = {
       return
     end
     vim.cmd('IBLDisable')
-  end
+  end,
+
+  is_active = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local ok, conf = pcall(require, 'ibl.config')
+    if not ok or type(conf.get_config) ~= 'function' then return nil end
+    local c = conf.get_config(bufnr)
+    if c == nil then return nil end
+    return c.enabled
+  end,
 }
 
 
@@ -178,12 +176,6 @@ local vimopts_disabled = false
 M.vimopts = {
   on = true,
   defer = false,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableVimopts', M.vimopts.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableVimopts', M.vimopts.disable, {})
-  end,
-
   enable = function()
     if vimopts_disabled == true then
       vim.opt_local.swapfile = vimopts_backup.swapfile
@@ -213,7 +205,16 @@ M.vimopts = {
     vim.opt_local.undoreload = 0
     vim.opt_local.list = false
     vim.opt_local.spell = false
-  end
+  end,
+
+  is_active = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    -- "Active" = opts have NOT been clamped by our disable. Use undolevels
+    -- as the proxy; -1 is the value we set on disable.
+    local undolevels = vim.api.nvim_get_option_value("undolevels",
+      { buf = bufnr, scope = "local" })
+    return undolevels ~= -1
+  end,
 }
 
 -- Syntax
@@ -224,12 +225,6 @@ local syntax_disabled = false
 M.syntax = {
   on = true,
   defer = true,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableSyntax', M.syntax.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableSyntax', M.syntax.disable, {})
-  end,
-
   enable = function()
     if syntax_disabled == true then
       vim.opt_local.syntax = syntax_backup.syntax
@@ -244,7 +239,14 @@ M.syntax = {
     end
     vim.cmd 'syntax clear'
     vim.opt_local.syntax = 'off'
-  end
+  end,
+
+  is_active = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local syn = vim.api.nvim_get_option_value("syntax",
+      { buf = bufnr, scope = "local" })
+    return syn ~= "" and syn ~= "off" and syn ~= "OFF"
+  end,
 }
 
 
@@ -256,12 +258,6 @@ local filetype_disabled = false
 M.filetype = {
   on = true,
   defer = true,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableFiletype', M.filetype.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableFiletype', M.filetype.disable, {})
-  end,
-
   enable = function()
     if filetype_disabled == true then
       vim.opt_local.filetype = filetype_backup.filetype
@@ -275,7 +271,14 @@ M.filetype = {
       filetype_disabled = true
     end
     vim.opt_local.filetype = ""
-  end
+  end,
+
+  is_active = function(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local ft = vim.api.nvim_get_option_value("filetype",
+      { buf = bufnr, scope = "local" })
+    return ft ~= ""
+  end,
 }
 
 -- Lualine
@@ -284,45 +287,51 @@ M.filetype = {
 M.lualine = {
   on = true,
   defer = false,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableLualine', M.lualine.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableLualine', M.lualine.disable, {})
-  end,
-
+  -- lualine doesn't expose a public is_hidden query, and probing &statusline
+  -- isn't reliable across configs. Track state ourselves with a global var.
   enable = function()
     pcall(function()
       require('lualine').hide({ unhide = true })
+      vim.g.faster_lualine_hidden = false
     end)
   end,
 
   disable = function()
     pcall(function()
       require('lualine').hide()
+      vim.g.faster_lualine_hidden = true
     end)
-  end
+  end,
+
+  is_active = function(_)
+    -- nil = we never touched lualine, assume it's running (the default)
+    if vim.g.faster_lualine_hidden == nil then return true end
+    return not vim.g.faster_lualine_hidden
+  end,
 }
 
 M.mini_clue = {
   on = true,
   defer = false,
-
-  commands = function()
-    vim.api.nvim_create_user_command('FasterEnableMiniClue', M.mini_clue.enable, {})
-    vim.api.nvim_create_user_command('FasterDisableMiniClue', M.mini_clue.disable, {})
-  end,
-
+  -- mini.clue has no public is_disabled query; track state ourselves.
   enable = function()
     pcall(function()
       MiniClue.enable_all_triggers()
+      vim.g.faster_mini_clue_disabled = false
     end)
   end,
 
   disable = function()
     pcall(function()
       MiniClue.disable_all_triggers()
+      vim.g.faster_mini_clue_disabled = true
     end)
-  end
+  end,
+
+  is_active = function(_)
+    if vim.g.faster_mini_clue_disabled == nil then return true end
+    return not vim.g.faster_mini_clue_disabled
+  end,
 }
 
 return M

--- a/lua/faster/longline.lua
+++ b/lua/faster/longline.lua
@@ -1,0 +1,169 @@
+local utils = require('faster.utils')
+
+-- Returns (size_mib_rounded_to_one_decimal, raw_size_bytes) or nil.
+local function get_buf_size(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local ok, stats = pcall(function()
+    return vim.loop.fs_stat(vim.api.nvim_buf_get_name(bufnr))
+  end)
+  if not (ok and stats) then
+    return
+  end
+  local size_mib = math.floor(0.5 + (stats.size / (1024 * 1024)) * 10) / 10
+  return size_mib, stats.size
+end
+
+-- Returns true when the buffer matches the long-line criteria, false otherwise.
+local function is_longline(bufnr, min_filesize, avg_threshold)
+  local size_mib, size_bytes = get_buf_size(bufnr)
+  if not size_bytes then return false, 0, 0 end
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  if line_count == 0 then return false, size_mib or 0, 0 end
+  local avg = size_bytes / line_count
+  return (size_mib >= min_filesize) and (avg > avg_threshold), size_mib, avg
+end
+
+local function emit_notify(bufnr, size_mib, avg)
+  local fname = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
+  local msg = string.format(
+    "faster.nvim active for %s (%d bytes/line, %s MiB)",
+    fname, math.floor(avg), size_mib
+  )
+  local function emit()
+    vim.notify(msg, vim.log.levels.INFO, { title = "faster.nvim" })
+  end
+  if vim.v.vim_did_enter == 1 then
+    emit()
+  else
+    -- During startup our notify can race plugins that replace vim.notify
+    -- (nvim-notify, noice, snacks) since they typically load on User VeryLazy
+    -- (lazy.nvim) or similar. Chain on User VeryLazy first — by the time it
+    -- fires, those plugins have run their config. Fall back to UIEnter+timer
+    -- in case the plugin manager doesn't fire VeryLazy.
+    local fired = false
+    local function fire()
+      if fired then return end
+      fired = true
+      emit()
+    end
+    pcall(vim.api.nvim_create_autocmd, "User", {
+      pattern = "VeryLazy",
+      once = true,
+      callback = fire,
+    })
+    vim.api.nvim_create_autocmd("UIEnter", {
+      once = true,
+      callback = function() vim.defer_fn(fire, 500) end,
+    })
+  end
+end
+
+-- Run disable for features at one defer level inside the bufnr's context.
+local function run_disable_pass(bufnr, defer)
+  vim.api.nvim_buf_call(bufnr, function()
+    utils.run_on_features(
+      FasterConfig.behaviours.longline.features_disabled,
+      function(f) f.disable() end,
+      function(f) return f.defer == defer end
+    )
+  end)
+end
+
+local function enable_features(defer)
+  utils.run_on_features(
+    FasterConfig.behaviours.longline.features_disabled,
+    function(f) f.enable() end,
+    function(f) return f.defer == defer end
+  )
+end
+
+-- The full disable sequence for one buffer. Three passes:
+--   1. defer=false (treesitter, lsp, illuminate, ...)
+--   2. defer=true  (syntax='off', filetype='', vimopts) — note that setting
+--      filetype synchronously fires FileType autocmds, which user code may
+--      use to re-enable defer=false features (e.g. vim.treesitter.start).
+--   3. defer=false again, deferred to the next tick — overrides any re-enable
+--      caused by pass 2's FileType chain.
+local function disable_for_buffer(bufnr, fs, avg)
+  -- Mark per-buffer so :Faster status can report "longline triggered for this buffer".
+  pcall(vim.api.nvim_buf_set_var, bufnr, 'faster_longline_triggered', true)
+  run_disable_pass(bufnr, false)
+  run_disable_pass(bufnr, true)
+  vim.schedule(function()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      run_disable_pass(bufnr, false)
+    end
+  end)
+end
+
+local M = {}
+
+local function process_buffer(bufnr, fs, avg_threshold)
+  vim.schedule(function()
+    if not vim.api.nvim_buf_is_valid(bufnr) then return end
+    local match, size_mib, avg = is_longline(bufnr, fs, avg_threshold)
+    if not match then return end
+    local cfg = FasterConfig.behaviours.longline
+    if cfg.notify then emit_notify(bufnr, size_mib, avg) end
+    disable_for_buffer(bufnr, fs, avg_threshold)
+  end)
+end
+
+function M.init(opts)
+  opts = opts or {}
+  local augroup = vim.api.nvim_create_augroup('faster_longline', {})
+
+  local cfg = FasterConfig.behaviours.longline
+
+  vim.api.nvim_create_autocmd("BufReadPost", {
+    pattern = cfg.pattern,
+    group = augroup,
+    callback = function(args)
+      process_buffer(args.buf, cfg.filesize, cfg.avg_bytes_per_line)
+    end,
+    desc = string.format(
+      "[faster.nvim] long-line rule: avg bytes/line > %d, size >= %s MiB",
+      cfg.avg_bytes_per_line, cfg.filesize
+    ),
+  })
+
+  for _, override in ipairs(cfg.extra_patterns or {}) do
+    if override.pattern ~= nil then
+      local fs  = override.filesize           or cfg.filesize
+      local avg = override.avg_bytes_per_line or cfg.avg_bytes_per_line
+      vim.api.nvim_create_autocmd("BufReadPost", {
+        pattern = override.pattern,
+        group = augroup,
+        callback = function(args)
+          process_buffer(args.buf, fs, avg)
+        end,
+        desc = string.format(
+          "[faster.nvim] long-line rule for `%s`: avg bytes/line > %d, size >= %s MiB",
+          override.pattern, avg, fs
+        ),
+      })
+    end
+  end
+
+  -- Process the currently open buffer too (e.g. when init() is called via
+  -- :Faster enable longline on an already-open long-line file). Skip when
+  -- called from a group enable so we don't undo the just-enabled features.
+  if not opts.skip_current then
+    local cur = vim.api.nvim_get_current_buf()
+    if vim.api.nvim_buf_get_name(cur) ~= "" then
+      process_buffer(cur, cfg.filesize, cfg.avg_bytes_per_line)
+    end
+  end
+end
+
+function M.stop()
+  vim.api.nvim_del_augroup_by_name('faster_longline')
+  enable_features(false)
+  enable_features(true)
+  -- Clear stale per-buffer "triggered" markers.
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    pcall(vim.api.nvim_buf_del_var, bufnr, 'faster_longline_triggered')
+  end
+end
+
+return M

--- a/lua/faster/macro.lua
+++ b/lua/faster/macro.lua
@@ -2,7 +2,39 @@ local utils = require('faster.utils')
 
 local M = {}
 
-local function execute_macro()
+local cleanup_autocmd_id = nil
+local saved_eventignore = nil
+local saved_lazyredraw = nil
+
+local function restore_after_macro()
+  cleanup_autocmd_id = nil
+
+  if saved_eventignore ~= nil then
+    vim.o.eventignore = saved_eventignore
+    saved_eventignore = nil
+  end
+
+  if saved_lazyredraw ~= nil then
+    vim.o.lazyredraw = saved_lazyredraw
+    saved_lazyredraw = nil
+  end
+
+  vim.keymap.set({ 'n' }, '@', M._execute_macro)
+
+  utils.run_on_features(
+    FasterConfig.behaviours.fastmacro.features_disabled,
+    function(f) f.enable() end,
+    function(f) return f.defer == true end
+  )
+
+  utils.run_on_features(
+    FasterConfig.behaviours.fastmacro.features_disabled,
+    function(f) f.enable() end,
+    function(f) return f.defer == false end
+  )
+end
+
+function M._execute_macro()
   local reg = vim.fn.nr2char(vim.fn.getchar())
 
   utils.run_on_features(
@@ -22,37 +54,41 @@ local function execute_macro()
 
   vim.keymap.del('n', '@')
 
-  xpcall(
-    function()
-      vim.cmd('noautocmd normal! ' .. count .. '@' .. reg)
-    end,
-    function(e)
-      utils.print_error(e)
-    end
-  )
+  -- Suppress autocommands and screen redraws during macro execution
+  saved_eventignore = vim.o.eventignore
+  vim.o.eventignore = 'all'
+  saved_lazyredraw = vim.o.lazyredraw
+  vim.o.lazyredraw = true
 
-  vim.keymap.set({ 'n' }, '@', execute_macro)
+  cleanup_autocmd_id = vim.api.nvim_create_autocmd('SafeState', {
+    once = true,
+    callback = restore_after_macro,
+  })
 
-  utils.run_on_features(
-    FasterConfig.behaviours.fastmacro.features_disabled,
-    function(f) f.enable() end,
-    function(f) return f.defer == true end
-  )
-
-  utils.run_on_features(
-    FasterConfig.behaviours.fastmacro.features_disabled,
-    function(f) f.enable() end,
-    function(f) return f.defer == false end
-  )
-
+  vim.fn.feedkeys(count .. '@' .. reg, '')
 end
 
 function M.init()
-  vim.keymap.set({ 'n' }, '@', execute_macro)
+  vim.keymap.set({ 'n' }, '@', M._execute_macro)
 end
 
 function M.stop()
   vim.keymap.del('n', '@')
+
+  if cleanup_autocmd_id then
+    vim.api.nvim_del_autocmd(cleanup_autocmd_id)
+    cleanup_autocmd_id = nil
+  end
+
+  if saved_eventignore ~= nil then
+    vim.o.eventignore = saved_eventignore
+    saved_eventignore = nil
+  end
+
+  if saved_lazyredraw ~= nil then
+    vim.o.lazyredraw = saved_lazyredraw
+    saved_lazyredraw = nil
+  end
 
   utils.run_on_features(
     FasterConfig.behaviours.fastmacro.features_disabled,


### PR DESCRIPTION
…nals

BREAKING CHANGE: 27 per-target commands removed (FasterEnable*/Disable* for each behaviour and feature, plus FasterPrintConfig). All runtime control now goes through a single user command:

  :Faster <action> [target]
    actions: enable | disable | config | status | help
    targets: behaviour name (bigfile|longline|fastmacro), feature name
             (treesitter|lsp|syntax|...), or group (features|behaviours|all)

Migration: FasterEnableBigfile -> :Faster enable bigfile, etc. Tab-completion suggests valid actions/targets.

Features:
- New `longline` behaviour: catches files with very long lines (minified JS/CSS, etc.) via filesize/line_count heuristic. Defaults: 10 KiB min size, 250 bytes/line. Toggle via behaviours.longline.notify.
- :Faster status shows runtime `active` state per behaviour and feature, not just static `on` config.
- :Faster enable/disable for behaviours processes the current buffer too (no :e! needed); group enable skips this so just-enabled features stay on.
- bigfile activation now emits a one-shot vim.notify (toggle via behaviours.bigfile.notify, default true).

Fixes:
- treesitter feature rewritten to vim.treesitter.start/stop (stable since 0.9). Old TSBufDisable path silently no-op'd on nvim-treesitter v1 main; both bigfile AND longline now actually disable treesitter highlighting.
- illuminate feature uses require('illuminate').pause_buf() so lazy-loaded illuminate actually pauses; user-command path no-op'd at BufReadPost.
- Three-pass disable (defer=false, defer=true, defer=false redo on next tick) overrides re-enables triggered when filetype="" synchronously fires FileType and user code (e.g. vim.treesitter.start) re-attaches features.
- Recursive macro: switched execution from vim.cmd('normal!') to feedkeys with SafeState cleanup; suppresses autocommands/redraws during the run.
- lsp.enable warns when &filetype is empty (silent no-op was confusing on bigfile/longline-disabled buffers).
- illuminate.enable refreshes highlights immediately after resume.

README: rewritten Commands section, new :Faster status section with column semantics and example output, longline configuration documented.