### PR TITLE
Fix fastmacro: re-enable features after macro

### DIFF
--- a/lua/faster/macro.lua
+++ b/lua/faster/macro.lua
@@ -2,12 +2,16 @@ local utils = require('faster.utils')
 
 local M = {}
 
-local cleanup_autocmd_id = nil
+local cleanup_pending = false
 local saved_eventignore = nil
 local saved_lazyredraw = nil
+local macro_seen = false
+local idle_polls = 0
 
 local function restore_after_macro()
-  cleanup_autocmd_id = nil
+  cleanup_pending = false
+  macro_seen = false
+  idle_polls = 0
 
   if saved_eventignore ~= nil then
     vim.o.eventignore = saved_eventignore
@@ -34,6 +38,37 @@ local function restore_after_macro()
   )
 end
 
+-- Poll vim.fn.reg_executing() to detect "macro is done" without relying on
+-- autocmds. Autocmds are blocked by eventignore='all' (which we want for
+-- max macro throughput); libuv timers (used by vim.defer_fn) are not.
+--
+-- Transitions: reg_executing() goes "" -> <reg> -> "" across the lifetime
+-- of one macro invocation. We watch for that arc. If the macro completes
+-- before the first poll (sub-millisecond macros), we bail after ~100 ms of
+-- idle polls so cleanup still runs.
+local function poll_macro_done()
+  if not cleanup_pending then return end
+
+  if vim.fn.reg_executing() ~= "" then
+    -- Macro is currently running; reset idle counter.
+    macro_seen = true
+    idle_polls = 0
+    vim.defer_fn(poll_macro_done, 10)
+  elseif macro_seen then
+    -- We saw it running, now it's done.
+    restore_after_macro()
+  else
+    -- Macro hasn't started yet (or completed before first poll). Re-check
+    -- after 10 ms; bail out and clean up after ~100 ms of no activity.
+    idle_polls = idle_polls + 1
+    if idle_polls >= 10 then
+      restore_after_macro()
+    else
+      vim.defer_fn(poll_macro_done, 10)
+    end
+  end
+end
+
 function M._execute_macro()
   local reg = vim.fn.nr2char(vim.fn.getchar())
 
@@ -54,18 +89,24 @@ function M._execute_macro()
 
   vim.keymap.del('n', '@')
 
-  -- Suppress autocommands and screen redraws during macro execution
+  -- Suppress autocommands AND screen redraws during macro execution.
+  -- eventignore = 'all' is fine here because we don't rely on autocmds for
+  -- cleanup detection; the poller uses vim.defer_fn (libuv timer) which is
+  -- not blocked by eventignore.
   saved_eventignore = vim.o.eventignore
   vim.o.eventignore = 'all'
   saved_lazyredraw = vim.o.lazyredraw
   vim.o.lazyredraw = true
 
-  cleanup_autocmd_id = vim.api.nvim_create_autocmd('SafeState', {
-    once = true,
-    callback = restore_after_macro,
-  })
+  cleanup_pending = true
+  macro_seen = false
+  idle_polls = 0
 
   vim.fn.feedkeys(count .. '@' .. reg, '')
+
+  -- First poll fires ASAP (next event tick) so short macros' cleanup is
+  -- essentially instant; subsequent polls run at 10 ms cadence.
+  vim.defer_fn(poll_macro_done, 0)
 end
 
 function M.init()
@@ -75,10 +116,9 @@ end
 function M.stop()
   vim.keymap.del('n', '@')
 
-  if cleanup_autocmd_id then
-    vim.api.nvim_del_autocmd(cleanup_autocmd_id)
-    cleanup_autocmd_id = nil
-  end
+  cleanup_pending = false
+  macro_seen = false
+  idle_polls = 0
 
   if saved_eventignore ~= nil then
     vim.o.eventignore = saved_eventignore


### PR DESCRIPTION
eventignore='all' was blocking the SafeState autocmd we used for cleanup, so lualine/mini_clue stayed disabled after a macro. Switch to a libuv timer (vim.defer_fn) polling vim.fn.reg_executing() — not blocked by eventignore. Idle-poll fallback handles sub-millisecond macros.