### PR TITLE
fix(behaviours): make stop() idempotent

### DIFF
--- a/lua/faster/bigfile.lua
+++ b/lua/faster/bigfile.lua
@@ -150,7 +150,10 @@ function M.init(opts)
 end
 
 function M.stop()
-  vim.api.nvim_del_augroup_by_name('faster_bigfile')
+  -- pcall: stop() may be called when the augroup doesn't exist (behaviour was
+  -- never armed, or already stopped). nvim_del_augroup_by_name errors on a
+  -- missing group, so guard to keep stop() idempotent.
+  pcall(vim.api.nvim_del_augroup_by_name, 'faster_bigfile')
   enable_features(true)
   enable_features(false)
   -- Clear stale per-buffer "triggered" markers so :Faster status reports

--- a/lua/faster/longline.lua
+++ b/lua/faster/longline.lua
@@ -157,7 +157,9 @@ function M.init(opts)
 end
 
 function M.stop()
-  vim.api.nvim_del_augroup_by_name('faster_longline')
+  -- pcall to keep stop() idempotent: nvim_del_augroup_by_name errors if the
+  -- group doesn't exist (behaviour never armed or already stopped).
+  pcall(vim.api.nvim_del_augroup_by_name, 'faster_longline')
   -- Restore defer=true features (filetype, syntax, vimopts) BEFORE defer=false
   -- ones: lsp.enable() bails with a warning when &filetype is still empty, so
   -- filetype must be back first. Matches bigfile.stop() and the group-enable

--- a/lua/faster/macro.lua
+++ b/lua/faster/macro.lua
@@ -138,7 +138,9 @@ function M.init()
 end
 
 function M.stop()
-  vim.keymap.del('n', '@')
+  -- pcall to keep stop() idempotent: vim.keymap.del errors if the mapping is
+  -- absent (fastmacro never armed, or already stopped).
+  pcall(vim.keymap.del, 'n', '@')
 
   cleanup_pending = false
   macro_seen = false


### PR DESCRIPTION
nvim_del_augroup_by_name and vim.keymap.del both error when the target is already gone, so disabling a behaviour twice (or :Faster disable all while one is already off) threw E367/E31. Wrap the augroup deletions in bigfile/longline stop() and the stop-path keymap.del in macro.stop() with pcall. The keymap.del inside _execute_macro is left as-is; the mapping always exists there.