### PR TITLE
refactor(utils): remove dead behaviour helper functions

### DIFF
--- a/lua/faster/utils.lua
+++ b/lua/faster/utils.lua
@@ -10,24 +10,6 @@ function M.print_config()
   print(vim.inspect(FasterConfig))
 end
 
--- BEHAVIOURS
-
-function M.enable_fast_macro()
-  FasterConfig.behaviours.fastmacro.init()
-end
-
-function M.disable_fast_macro()
-  FasterConfig.behaviours.fastmacro.stop()
-end
-
-function M.enable_big_file()
-  FasterConfig.behaviours.bigfile.init()
-end
-
-function M.disable_big_file()
-  FasterConfig.behaviours.bigfile.stop()
-end
-
 -- FEATURES
 
 function M.enable_all_features()


### PR DESCRIPTION
enable_fast_macro/disable_fast_macro/enable_big_file/disable_big_file were unused — commands.lua drives behaviours generically via b.init()/b.stop(). Leftovers from before the unified-command refactor (no longline equivalents).